### PR TITLE
Adding source field to schema of Raw zone

### DIFF
--- a/docs/schema/mda_raw_zone_schema.md
+++ b/docs/schema/mda_raw_zone_schema.md
@@ -2,12 +2,13 @@
 | name               | type       | mandatory  | description                                                                 | example                                       |
 +====================+============+============+=============================================================================+===============================================+
 | meter_id           | String     | X          | The ID of a physical meter                                                  | 123456                                        |
-| reading_value      | Double     | X          | the value of the reading                                                    | 0                                             |
+| reading_value      | Double     | X          | The value of the reading                                                    | 0                                             |
 | reading_type       | String     | X          | Classification of the reading, can be energy, voltage, current and similar  | Energy|NegativeEnergy|Current|Demand|Voltage  |
-| unit               | String     |            | unit of measurement (uom)                                                    | V|kwh|A|...                                   |
-| reading_date_time  | Timestamp  | X          | the time the reading was taken                                              | yyyy-MM-dd HH:mm:ss.SSS                       |
+| unit               | String     |            | Unit of measurement (uom)                                                   | V|kwh|A|...                                   |
+| reading_date_time  | Timestamp  | X          | The time the reading was taken                                              | yyyy-MM-dd HH:mm:ss.SSS                       |
 | obis_code          | String     |            | Obis Code of the register                                                   |                                               |
 | phase              | String     |            | Phase on which the meter is connected                                       |                                               |
+| reading_source     | String     |            | The source of the reading if record came from HES or batch readings         | HES | B                                       |
 |                    |            |            |                                                                             |                                               |
 |                    |            |            |                                                                             |                                               |
 +--------------------+------------+------------+-----------------------------------------------------------------------------+-----------------------------------------------+

--- a/docs/schema/mda_raw_zone_schema.schema.json
+++ b/docs/schema/mda_raw_zone_schema.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aws-quickstart.github.io/quickstart-aws-utility-meter-data-analytics-platform/meterdata",
+  "title": "meterdata",
+  "description": "A meter reading as received from input systems broken down to a single reading per record",
+  "type": "object",
+  "properties": {
+    "meter_id": {
+      "type": "string",
+      "description": "The ID of a physical meter",
+      "examples": [
+        "123456"
+      ]
+    },
+    "reading_value": {
+      "type": "number",
+      "description": "The value of the reading",
+      "examples": [
+        "0"
+      ]
+    },
+    "reading_type": {
+      "type": "string",
+      "description": "Classification of the reading, can be energy, voltage, current and similar",
+      "examples": [
+        "Energy",
+        "NegativeEnergy",
+        "Current",
+        "Demand",
+        "Voltage"
+      ]
+    },
+    "unit": {
+      "type": "string",
+      "description": "Unit of measurement (uom)",
+      "examples": [
+        "V",
+        "kwh",
+        "A"
+      ]
+    },
+    "reading_date_time": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The time the reading was taken",
+      "examples": [
+        "yyyy-MM-dd HH:mm:ss.SSS"
+      ]
+    },
+    "obis_code": {
+      "type": "string",
+      "description": "Obis Code of the register"
+    },
+    "phase": {
+      "type": "string",
+      "description": "Phase on which the meter is connected"
+    },
+    "reading_source": {
+      "type": "string",
+      "description": "The source of the reading if record came from HES or batch readings",
+      "enum": [
+        "HES",
+        "B",
+        null
+      ],
+      "default": "B",
+      "examples": [
+        "HES",
+        "B",
+        null
+      ]
+    }
+  },
+  "required": [
+    "meter_id",
+    "reading_value",
+    "reading_type",
+    "reading_date_time"
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:* none

*Description of changes:*

- Row zone schema now has optional field to allow for identifying records coming directly from head-end systems vs records from batch readings
- Field name reading_source with values HES or B
- Adding raw schema as a JSON Schema format as well as ASCII art schema (should be deprecated in the future)
- Fixed punctuation mistakes on old description in ASCII art schema field descriptions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
