### PR TITLE
Added a map for specifying the ARN for the LambdaInsightsExtension layer

### DIFF
--- a/templates/dataflow/meterreading/meterreading.dataflow.inputadapter.template.yaml
+++ b/templates/dataflow/meterreading/meterreading.dataflow.inputadapter.template.yaml
@@ -110,6 +110,63 @@ Mappings:
     csv:
       RangeExtractorFunctionName: adapter_csv_inbound_file_range_extractor
       WorkerFunctionName: adapter_csv_inbound_file_range_worker
+  ExtensionsMap:
+    us-east-1:
+      LambdaInsightsLayer: "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:35"
+    us-east-2:
+      LambdaInsightsLayer: "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:33"
+    us-west-1:
+      LambdaInsightsLayer: "arn:aws:lambda:us-west-1:580247275435:layer:LambdaInsightsExtension:33"
+    us-west-2:
+      LambdaInsightsLayer: "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:33"
+    af-south-1:
+      LambdaInsightsLayer: "arn:aws:lambda:af-south-1:012438385374:layer:LambdaInsightsExtension:25"
+    ap-east-1:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-east-1:519774774795:layer:LambdaInsightsExtension:25"
+    ap-south-2:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-south-2:891564319516:layer:LambdaInsightsExtension:8"
+    ap-southeast-3:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-southeast-3:439286490199:layer:LambdaInsightsExtension:11"
+    ap-south-1:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-south-1:580247275435:layer:LambdaInsightsExtension:31"
+    ap-northeast-3:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-northeast-3:194566237122:layer:LambdaInsightsExtension:2"
+    ap-northeast-2:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-northeast-2:580247275435:layer:LambdaInsightsExtension:32"
+    ap-southeast-1:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-southeast-1:580247275435:layer:LambdaInsightsExtension:33"
+    ap-southeast-2:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-southeast-2:580247275435:layer:LambdaInsightsExtension:33"
+    ap-northeast-1:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:50"
+    ca-central-1:
+      LambdaInsightsLayer: "arn:aws:lambda:ca-central-1:580247275435:layer:LambdaInsightsExtension:32"
+    cn-north-1:
+      LambdaInsightsLayer: "arn:aws-cn:lambda:cn-north-1:488211338238:layer:LambdaInsightsExtension:26"
+    cn-northwest-1:
+      LambdaInsightsLayer: "arn:aws-cn:lambda:cn-northwest-1:488211338238:layer:LambdaInsightsExtension:26"
+    eu-central-1:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension:35"
+    eu-west-1:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:33"
+    eu-west-2:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-west-2:580247275435:layer:LambdaInsightsExtension:33"
+    eu-south-1:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-south-1:339249233099:layer:LambdaInsightsExtension:25"
+    eu-west-3:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-west-3:580247275435:layer:LambdaInsightsExtension:32"
+    eu-south-2:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-south-2:352183217350:layer:LambdaInsightsExtension:10"
+    eu-north-1:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-north-1:580247275435:layer:LambdaInsightsExtension:30"
+    eu-central-2:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-central-2:033019950311:layer:LambdaInsightsExtension:7"
+    me-south-1:
+      LambdaInsightsLayer: "arn:aws:lambda:me-south-1:285320876703:layer:LambdaInsightsExtension:25"
+    me-central-1:
+      LambdaInsightsLayer: "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:9"
+    sa-east-1:
+      LambdaInsightsLayer: "arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension:32"
 
 Conditions:
   UsingDefaultBucket: !Equals [ !Ref QSS3BucketName, 'aws-quickstart' ]
@@ -170,7 +227,7 @@ Resources:
       Runtime: python3.9
       Role: !GetAtt 'RunRangeExtractorLambdaRole.Arn'
       Layers:
-        - !Sub "arn:aws:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension:21"
+        - !FindInMap [ ExtensionsMap, !Ref "AWS::Region", "LambdaInsightsLayer" ]
       Environment:
         Variables:
           range_queue_url: !Ref InboundFileRangeQueue
@@ -226,7 +283,7 @@ Resources:
       Role: !GetAtt RunRangeWorkerLambdaRole.Arn
       Layers:
         - !Ref KinesisProducerDependencyLayer
-        - !Sub "arn:aws:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension:21"
+        - !FindInMap [ ExtensionsMap, !Ref "AWS::Region", "LambdaInsightsLayer" ]
       Environment:
         Variables:
           staging_record_stream: !Ref StagingRecordsStream

--- a/templates/feature/api/api.feature.template.yaml
+++ b/templates/feature/api/api.feature.template.yaml
@@ -77,6 +77,65 @@ Outputs:
   ApiEndpoint:
     Value: !Sub https://${MdaApiGateway}.execute-api.us-east-1.amazonaws.com
 
+Mappings:
+  ExtensionsMap:
+    us-east-1:
+      LambdaInsightsLayer: "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:35"
+    us-east-2:
+      LambdaInsightsLayer: "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:33"
+    us-west-1:
+      LambdaInsightsLayer: "arn:aws:lambda:us-west-1:580247275435:layer:LambdaInsightsExtension:33"
+    us-west-2:
+      LambdaInsightsLayer: "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:33"
+    af-south-1:
+      LambdaInsightsLayer: "arn:aws:lambda:af-south-1:012438385374:layer:LambdaInsightsExtension:25"
+    ap-east-1:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-east-1:519774774795:layer:LambdaInsightsExtension:25"
+    ap-south-2:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-south-2:891564319516:layer:LambdaInsightsExtension:8"
+    ap-southeast-3:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-southeast-3:439286490199:layer:LambdaInsightsExtension:11"
+    ap-south-1:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-south-1:580247275435:layer:LambdaInsightsExtension:31"
+    ap-northeast-3:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-northeast-3:194566237122:layer:LambdaInsightsExtension:2"
+    ap-northeast-2:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-northeast-2:580247275435:layer:LambdaInsightsExtension:32"
+    ap-southeast-1:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-southeast-1:580247275435:layer:LambdaInsightsExtension:33"
+    ap-southeast-2:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-southeast-2:580247275435:layer:LambdaInsightsExtension:33"
+    ap-northeast-1:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:50"
+    ca-central-1:
+      LambdaInsightsLayer: "arn:aws:lambda:ca-central-1:580247275435:layer:LambdaInsightsExtension:32"
+    cn-north-1:
+      LambdaInsightsLayer: "arn:aws-cn:lambda:cn-north-1:488211338238:layer:LambdaInsightsExtension:26"
+    cn-northwest-1:
+      LambdaInsightsLayer: "arn:aws-cn:lambda:cn-northwest-1:488211338238:layer:LambdaInsightsExtension:26"
+    eu-central-1:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension:35"
+    eu-west-1:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:33"
+    eu-west-2:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-west-2:580247275435:layer:LambdaInsightsExtension:33"
+    eu-south-1:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-south-1:339249233099:layer:LambdaInsightsExtension:25"
+    eu-west-3:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-west-3:580247275435:layer:LambdaInsightsExtension:32"
+    eu-south-2:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-south-2:352183217350:layer:LambdaInsightsExtension:10"
+    eu-north-1:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-north-1:580247275435:layer:LambdaInsightsExtension:30"
+    eu-central-2:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-central-2:033019950311:layer:LambdaInsightsExtension:7"
+    me-south-1:
+      LambdaInsightsLayer: "arn:aws:lambda:me-south-1:285320876703:layer:LambdaInsightsExtension:25"
+    me-central-1:
+      LambdaInsightsLayer: "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:9"
+    sa-east-1:
+      LambdaInsightsLayer: "arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension:32"
+
 Conditions:
   UsingDefaultBucket: !Equals [ !Ref QSS3BucketName, 'aws-quickstart' ]
 
@@ -107,7 +166,7 @@ Resources:
       MemorySize: 128
       Layers:
         - !Ref PyathenaDependencyLayer
-        - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension:21"
+        - !FindInMap [ ExtensionsMap, !Ref "AWS::Region", "LambdaInsightsLayer" ]
         - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:017000801446:layer:AWSLambdaPowertoolsPythonV2:17"
       Environment:
         Variables:

--- a/templates/feature/mlpipeline/mlpipeline.feature.template.yaml
+++ b/templates/feature/mlpipeline/mlpipeline.feature.template.yaml
@@ -34,6 +34,8 @@ Mappings:
       image: "669576153137.dkr.ecr.eu-north-1.amazonaws.com"
     eu-central-1:
       image: "495149712605.dkr.ecr.eu-central-1.amazonaws.com"
+    eu-south-2:
+      image: "503227376785.dkr.ecr.eu-south-2.amazonaws.com"
     eu-west-1:
       image: "224300973850.dkr.ecr.eu-west-1.amazonaws.com"
     eu-west-2:

--- a/templates/feature/voltvar/voltvar.feature.template.yaml
+++ b/templates/feature/voltvar/voltvar.feature.template.yaml
@@ -63,6 +63,65 @@ Parameters:
       can include numbers, lowercase letters, uppercase letters, hyphens (-), and
       forward slash (/).
 
+Mappings:
+  ExtensionsMap:
+    us-east-1:
+      LambdaInsightsLayer: "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:35"
+    us-east-2:
+      LambdaInsightsLayer: "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:33"
+    us-west-1:
+      LambdaInsightsLayer: "arn:aws:lambda:us-west-1:580247275435:layer:LambdaInsightsExtension:33"
+    us-west-2:
+      LambdaInsightsLayer: "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:33"
+    af-south-1:
+      LambdaInsightsLayer: "arn:aws:lambda:af-south-1:012438385374:layer:LambdaInsightsExtension:25"
+    ap-east-1:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-east-1:519774774795:layer:LambdaInsightsExtension:25"
+    ap-south-2:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-south-2:891564319516:layer:LambdaInsightsExtension:8"
+    ap-southeast-3:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-southeast-3:439286490199:layer:LambdaInsightsExtension:11"
+    ap-south-1:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-south-1:580247275435:layer:LambdaInsightsExtension:31"
+    ap-northeast-3:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-northeast-3:194566237122:layer:LambdaInsightsExtension:2"
+    ap-northeast-2:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-northeast-2:580247275435:layer:LambdaInsightsExtension:32"
+    ap-southeast-1:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-southeast-1:580247275435:layer:LambdaInsightsExtension:33"
+    ap-southeast-2:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-southeast-2:580247275435:layer:LambdaInsightsExtension:33"
+    ap-northeast-1:
+      LambdaInsightsLayer: "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:50"
+    ca-central-1:
+      LambdaInsightsLayer: "arn:aws:lambda:ca-central-1:580247275435:layer:LambdaInsightsExtension:32"
+    cn-north-1:
+      LambdaInsightsLayer: "arn:aws-cn:lambda:cn-north-1:488211338238:layer:LambdaInsightsExtension:26"
+    cn-northwest-1:
+      LambdaInsightsLayer: "arn:aws-cn:lambda:cn-northwest-1:488211338238:layer:LambdaInsightsExtension:26"
+    eu-central-1:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension:35"
+    eu-west-1:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:33"
+    eu-west-2:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-west-2:580247275435:layer:LambdaInsightsExtension:33"
+    eu-south-1:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-south-1:339249233099:layer:LambdaInsightsExtension:25"
+    eu-west-3:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-west-3:580247275435:layer:LambdaInsightsExtension:32"
+    eu-south-2:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-south-2:352183217350:layer:LambdaInsightsExtension:10"
+    eu-north-1:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-north-1:580247275435:layer:LambdaInsightsExtension:30"
+    eu-central-2:
+      LambdaInsightsLayer: "arn:aws:lambda:eu-central-2:033019950311:layer:LambdaInsightsExtension:7"
+    me-south-1:
+      LambdaInsightsLayer: "arn:aws:lambda:me-south-1:285320876703:layer:LambdaInsightsExtension:25"
+    me-central-1:
+      LambdaInsightsLayer: "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:9"
+    sa-east-1:
+      LambdaInsightsLayer: "arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension:32"
+
 Conditions:
   UsingDefaultBucket: !Equals [ !Ref QSS3BucketName, 'aws-quickstart' ]
 
@@ -94,7 +153,7 @@ Resources:
       Timeout: 120
       MemorySize: 128
       Layers:
-        - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension:21"
+        - !FindInMap [ ExtensionsMap, !Ref "AWS::Region", "LambdaInsightsLayer" ]
       Environment:
         Variables:
           volt_var_bucket: !Ref VoltVarBucket
@@ -116,7 +175,7 @@ Resources:
       MemorySize: 256
       Layers:
         - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:017000801446:layer:AWSLambdaPowertoolsPythonV2:17"
-        - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension:21"
+        - !FindInMap [ ExtensionsMap, !Ref "AWS::Region", "LambdaInsightsLayer" ]
       Environment:
         Variables:
           volt_var_calculation_queue: !GetAtt VoltVarCalculationQueue.QueueName
@@ -145,7 +204,7 @@ Resources:
       MemorySize: 128
       Layers:
         - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:017000801446:layer:AWSLambdaPowertoolsPythonV2:17"
-        - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension:21"
+        - !FindInMap [ ExtensionsMap, !Ref "AWS::Region", "LambdaInsightsLayer" ]
       Environment:
         Variables:
           DYNAMO_TABLE: !Ref VoltVarTable


### PR DESCRIPTION
*Issue #, if available:*
#84

*Description of changes:*
This PR adds a map with ARNs for the [Lambda Insights Extension](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights.html) layer, opening deployment to more regions.

It also changes the extension version from `1.0.143.0` (layer version `21` in `us-east-1`) to `1.0.178.0` (layer version `35` in `us-east-1`) as this was the first version of the extension to be supported in opt-in regions such as Asia Pacific (Hyderabad), Asia Pacific (Jakarta), Europe (Spain), Europe (Zurich) & Middle East (UAE).

It also adds the URI for the [Amazon SageMaker ECR repos](https://docs.aws.amazon.com/es_es/sagemaker/latest/dg-ecr-paths/ecr-eu-south-2.html) for `eu-south-2` (Spain) region to increase compatibility with the region, although the stack is not fully deployable there yet (Amazon Managed Grafana is not available at the time).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
